### PR TITLE
Very simple implementation of watch count

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --open",
     "server": "node ./src/server",
+    "server:debug": "nodemon --inspect src/server",
     "build": "webpack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -17,6 +18,7 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.0",
+    "nodemon": "^1.12.1",
     "webpack": "^3.5.6",
     "webpack-dev-server": "^2.7.1"
   },

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -9,3 +9,9 @@
     right: 12px;
     width: 300px;
 }
+
+.watchCount {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+}

--- a/src/client/components/App/action.js
+++ b/src/client/components/App/action.js
@@ -4,6 +4,7 @@ const Action = Type({
   PlaceBid: [],
   UpdateBidAmount: [ Number ],
   NewBidPlaced: [ Object ],
+  WatchCountChanged: [ Number ],
   Error: [ Object ]
 })
 

--- a/src/client/components/App/index.js
+++ b/src/client/components/App/index.js
@@ -25,6 +25,13 @@ Observable
   })
   .subscribe()
 
+Observable
+  .fromEvent(socket, 'watch_count')
+  .withLatestFrom(observableView.stream$, (watchCount, { state, dispatch }) => {
+    dispatch(Action.WatchCountChanged(watchCount))
+  })
+  .subscribe()
+
 export default {
   update: update(socket),
   view: observableView,

--- a/src/client/components/App/model.js
+++ b/src/client/components/App/model.js
@@ -17,6 +17,10 @@ export const update = socket => (state, action) => Action.case({
     })
     return {...state, error: null }
   },
+  WatchCountChanged: watchCount => {
+    state.watchCount = watchCount
+    return state
+  },
   Error: error => ({
     ...state, error
   })

--- a/src/client/components/App/view.js
+++ b/src/client/components/App/view.js
@@ -53,6 +53,12 @@ const view = ({ state, dispatch }) => (
       </div>
     </div>
 
+    {state.watchCount > 0 ?
+      <div className="watchCount">
+        Others watching: {state.watchCount}
+      </div>
+      : '' }
+
     {state.error ?
       <div classNames="alert alert-dismissible alert-danger toast">
         {state.error.message}

--- a/src/server/sockets/setup-connection.js
+++ b/src/server/sockets/setup-connection.js
@@ -5,6 +5,8 @@ const { getLotById, placeBid } = require('../facades/lot')
 const errorHandler = require('./error-handler')
 const crypto = require('crypto')
 
+let watchCount = 0 // TODO: major limitation -- this implementation assumes there is only one item!
+
 const generateName = value => crypto
       .createHash('md5')
       .update(value)
@@ -14,12 +16,20 @@ const generateName = value => crypto
 const setupConnection = io => socket => {
   const bidder = generateName(socket.id)
 
+  watchCount++
+  emitWatchCount(io, watchCount)
+
   const newBid$ = Observable.fromEvent(socket, 'new_bid')
         .map(bid => Object.assign(bid, { bidder }))
 
   const biddingForLot$ = newBid$
     .map(bid => Observable.from(getLotById(bid.lotId)))
     .mergeAll()
+
+  socket.on('disconnect', () => {
+    watchCount--
+    emitWatchCount(io, watchCount)
+  })
 
   return biddingForLot$
     .withLatestFrom(
@@ -28,6 +38,10 @@ const setupConnection = io => socket => {
     .mergeAll()
     .catch(errorHandler(socket))
     .do(bid => io.emit('new_bid_placed', bid))
+}
+
+function emitWatchCount(io, watchCount) {
+  io.emit('watch_count', watchCount - 1) //decrement by 1 as the current user should be excluded from count (alternatively, this can be done on client)
 }
 
 module.exports = setupConnection


### PR DESCRIPTION
See comments in setup-connection.js for limitations.

If more time spent, would enhance watchCount to store bidId and list of bidders (by generated name). Then when emitting an event could filter out the current bidder and return a proper watch count vs incrementing by 1.